### PR TITLE
Add update_env input to copilot_deploy

### DIFF
--- a/actions/copilot_deploy/action.yml
+++ b/actions/copilot_deploy/action.yml
@@ -10,6 +10,10 @@ inputs:
   image:
     description: the docker image+tag to deploy (omit to build/use what is in manifest.yml)
     required: false
+  update_env:
+    description: If the copilot env should be updated. Useful for when multiple jobs are deploying in parallel
+    required: false
+    default: true
 
 runs:
   using: composite
@@ -24,7 +28,7 @@ runs:
     - name: update copilot env
       shell: bash
       run: |
-        if [[ -f copilot/environments/${{inputs.environment}}/manifest.yml ]]; then
+        if [[ -f copilot/environments/${{inputs.environment}}/manifest.yml && ${{inputs.update_env}} == 'true' ]]; then
           copilot env deploy -n ${{inputs.environment}} --force
         fi
     - name: deploy


### PR DESCRIPTION
Adding this input so that multiple jobs can use this action at one time. The copilot env only really needs to be updated once, so adding this to be able to control which job should do that.

See [here](https://github.com/LumioHX/solflow-api/actions/runs/5094935140) for an example of a workflow failing w/o the input

[here](https://github.com/LumioHX/solflow-api/actions/runs/5334165987) of it passing with the input

An example of how this is used in [solflow-api](https://github.com/LumioHX/solflow-api/blob/master/.github/workflows/shared-deploy-2.yml#L110) currently: