### PR TITLE
bump dependency versions

### DIFF
--- a/actions/assume_role_through_hub_account/action.yml
+++ b/actions/assume_role_through_hub_account/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Assume Hub Account Role
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.hub_account_role }}
@@ -34,7 +34,7 @@ runs:
         mask-aws-account-id: false
 
     - name: Assume Target Account Role
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.target_account_role }}

--- a/actions/store_jest_coverage_report/action.yml
+++ b/actions/store_jest_coverage_report/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: checkout coverage repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.coverage_repo }}
         token: ${{ inputs.token }}


### PR DESCRIPTION
this is to get rid of deprecation warnings about being on node16.
changelogs indicate no breaking changes for these bumps.
